### PR TITLE
refactor(pkg/jenkins): change the state update logic

### DIFF
--- a/pkg/jenkins/controller.go
+++ b/pkg/jenkins/controller.go
@@ -365,7 +365,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, reports chan<- prowapi.P
 		case jb.IsRunning():
 			// Build still going.
 			c.incrementNumPendingJobs(pj.Spec.Job)
-			if pj.Status.Description == "Jenkins job running." {
+			if pj.Status.Description == "Jenkins job running." && pj.Status.URL != "" {
 				return nil
 			}
 			pj.Status.Description = "Jenkins job running."
@@ -429,7 +429,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 	// Record last known state so we can patch
 	prevPJ := pj.DeepCopy()
 
-	if _, jbExists := jbs[pj.ObjectMeta.Name]; !jbExists {
+	if jb, jbExists := jbs[pj.ObjectMeta.Name]; !jbExists {
 		// Do not start more jobs than specified.
 		if !c.canExecuteConcurrently(&pj) {
 			return nil
@@ -446,20 +446,30 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 			pj.Status.URL = c.cfg().StatusErrorLink
 			pj.Status.Description = "Error starting Jenkins job."
 		} else {
-			now := metav1.NewTime(c.clock.Now())
-			pj.Status.PendingTime = &now
-			pj.Status.State = prowapi.PendingState
 			pj.Status.Description = "Jenkins job enqueued."
 		}
 	} else {
-		// If a Jenkins build already exists for this job, advance the ProwJob to Pending and
-		// it should be handled by syncPendingJob in the next sync.
-		if pj.Status.PendingTime == nil {
-			now := metav1.NewTime(c.clock.Now())
-			pj.Status.PendingTime = &now
+		if jb.IsRunning() {
+			// If a Jenkins build already exists for this job, advance the ProwJob to Pending and
+			// it should be handled by syncPendingJob in the next sync.
+			if pj.Status.PendingTime == nil {
+				now := metav1.NewTime(c.clock.Now())
+				pj.Status.PendingTime = &now
+			}
+			pj.Status.State = prowapi.PendingState
+			pj.Status.Description = "Jenkins job running."
+
+			// Construct the status URL that will be used in reports.
+			pj.Status.PodName = pj.ObjectMeta.Name
+			pj.Status.BuildID = jb.BuildID()
+			pj.Status.JenkinsBuildID = strconv.Itoa(jb.Number)
+			var b bytes.Buffer
+			if err := c.config().JobURLTemplate.Execute(&b, &pj); err != nil {
+				c.log.WithFields(pjutil.ProwJobFields(&pj)).Errorf("error executing URL template: %v", err)
+			} else {
+				pj.Status.URL = b.String()
+			}
 		}
-		pj.Status.State = prowapi.PendingState
-		pj.Status.Description = "Jenkins job enqueued."
 	}
 	// Report to GitHub.
 	reports <- pj

--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -123,7 +123,7 @@ type JobInfo struct {
 
 // IsRunning means the job started but has not finished.
 func (jb *Build) IsRunning() bool {
-	return jb.Result == nil
+	return jb.Result == nil && !jb.enqueued
 }
 
 // IsSuccess means the job passed


### PR DESCRIPTION
- keep the prow job be `triggered` state until the jenkins build is running.
- only set the prow job be `pending` state when the jenkins build is running
  rather then the jenkins build enqueued.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>