### PR TITLE
feat(trigger): enhance comment handling to trigger GitHub Actions

### DIFF
--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -59,6 +59,11 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 
 	// Skip comments not germane to this plugin
 	textToCheck := markdown.DropCodeBlock(gc.Body)
+
+	// Check if this comment could trigger GitHub Actions
+	couldTriggerGitHubActions := trigger.TriggerGitHubWorkflows &&
+		(pjutil.RetestRe.MatchString(textToCheck) || pjutil.TestAllRe.MatchString(textToCheck))
+
 	if !pjutil.RetestRe.MatchString(textToCheck) &&
 		!pjutil.RetestRequiredRe.MatchString(textToCheck) &&
 		!pjutil.OkToTestRe.MatchString(textToCheck) &&
@@ -71,7 +76,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 				break
 			}
 		}
-		if !matched {
+		if !matched && !couldTriggerGitHubActions {
 			c.Logger.Debug("Comment doesn't match any triggering regex, skipping.")
 			return nil
 		}
@@ -159,7 +164,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 					})
 					runID := run.ID
 					// For action workflows awaiting approval, status is "completed" and conclusion is "action_required"
-					if run.Conclusion == "action_required" { 
+					if run.Conclusion == "action_required" {
 						go func() {
 							if err := c.GitHubClient.ApproveWorkflowRun(org, repo, runID); err != nil {
 								log.Errorf("attempt to approve github run failed: %v", err)


### PR DESCRIPTION
Relate to  https://github.com/PingCAP-QE/ci/issues/3531

- Added logic to check if a comment can trigger GitHub Actions based on specific regex patterns.
- Updated the condition to skip comments that do not match any triggering regex or could trigger GitHub Actions, improving the comment processing flow.

These changes enhance the functionality of the comment handling mechanism, allowing for better integration with GitHub Actions workflows.