### PR TITLE
refactor(external-plugins/cherrypick): add skipFork option and improve

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,33 @@
+name: Publish images
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - "**/*.go"
+      - go.mod
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  push-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+      - name: Log in to the Container registry
+        uses: ko-build/setup-ko@v0.8
+      - name: Build & Push images
+        env:
+          REGISTRY: ghcr.io/ti-community-infra/prow
+        run: |
+          make push-images REGISTRY=${REGISTRY}

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -534,7 +534,7 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 	titleTargetBranchIndicator := fmt.Sprintf(titleTargetBranchIndicatorTemplate, targetBranch)
 	title = fmt.Sprintf("%s%s", titleTargetBranchIndicator, omitBaseBranchFromTitle(title, baseBranch))
 
-	if err := s.applyToBranch(r, org, repo, targetBranch, localPath, num); err != nil {
+	if err := s.applyToBranch(r, org, repo, localPath, num); err != nil {
 		errs := []error{fmt.Errorf("failed to cherry-pick: %w", err)}
 		logger.WithError(err).Warn("failed to apply PR on top of target branch")
 		resp := fmt.Sprintf("#%d failed to apply on top of branch %q:\n```\n%v\n```", num, targetBranch, err)
@@ -610,9 +610,8 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 	return nil
 }
 
-func (s *Server) applyToBranch(r git.RepoClient, org, repo, targetBranch, localPath string, num int) error {
+func (s *Server) applyToBranch(r git.RepoClient, org, repo, localPath string, num int) error {
 	var errs []error
-	var errResponses []string
 
 	// try to apply the patch using git am.
 	{
@@ -621,7 +620,6 @@ func (s *Server) applyToBranch(r git.RepoClient, org, repo, targetBranch, localP
 			return nil
 		}
 		errs = append(errs, fmt.Errorf("[try 1] failed to `git am`: %w", err))
-		errResponses = append(errResponses, fmt.Sprintf("#%d failed to apply on top of branch %q:\n```\n%v\n```", num, targetBranch, err))
 	}
 	// try to cherry-pick the merge commit
 	{


### PR DESCRIPTION
patch application logic

- Introduce skipFork to allow pushing directly to central repo
- Refactor patch application into applyToBranch with fallback to cherry-pick
- Update ensureForkExists to respect skipFork
- Add TODOs for label handling after PR creation