### PR TITLE
opt(pkg/jenkins): honor Jenkins building flag in Build handling

### DIFF
--- a/pkg/jenkins/controller.go
+++ b/pkg/jenkins/controller.go
@@ -365,12 +365,6 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, reports chan<- prowapi.P
 		case jb.IsRunning():
 			// Build still going.
 			c.incrementNumPendingJobs(pj.Spec.Job)
-			// Do not update the commit status when build number is 0.
-			// Build number 0 indicates the Jenkins job hasn't been properly assigned a build number yet.
-			if jb.Number == 0 {
-				c.log.WithFields(pjutil.ProwJobFields(&pj)).Debug("Skipping status update for build with number 0")
-				return nil
-			}
 			if pj.Status.Description == "Jenkins job running." && pj.Status.URL != "" {
 				return nil
 			}
@@ -458,12 +452,6 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 		// Still in queue.
 		pj.Status.Description = "Jenkins job enqueued."
 	} else if jb.IsRunning() {
-		// Do not update the commit status when build number is 0.
-		// Build number 0 indicates the Jenkins job hasn't been properly assigned a build number yet.
-		if jb.Number == 0 {
-			c.log.WithFields(pjutil.ProwJobFields(&pj)).Debug("Skipping status update for build with number 0")
-			return nil
-		}
 		// If a Jenkins build already exists for this job, advance the ProwJob to Pending and
 		// it should be handled by syncPendingJob in the next sync.
 		if pj.Status.PendingTime == nil {

--- a/pkg/jenkins/controller_test.go
+++ b/pkg/jenkins/controller_test.go
@@ -310,7 +310,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 				},
 			},
 			builds: map[string]Build{
-				"zerobuild": {enqueued: false, Number: 0},
+				"zerobuild": {enqueued: false, Number: 0, Building: true},
 			},
 			expectedBuild:       false,
 			expectedReport:      false,
@@ -424,7 +424,7 @@ func TestSyncPendingJobs(t *testing.T) {
 				},
 			},
 			builds: map[string]Build{
-				"foofoo": {enqueued: true, Number: 10},
+				"foofoo": {enqueued: true, Number: 10, Building: false},
 			},
 			expectedState:    prowapi.TriggeredState,
 			expectedEnqueued: true,
@@ -445,7 +445,7 @@ func TestSyncPendingJobs(t *testing.T) {
 				},
 			},
 			builds: map[string]Build{
-				"boing": {enqueued: false, Number: 10},
+				"boing": {enqueued: false, Number: 10, Building: true},
 			},
 			expectedURL:      "boing/pending",
 			expectedState:    prowapi.PendingState,
@@ -467,7 +467,7 @@ func TestSyncPendingJobs(t *testing.T) {
 				},
 			},
 			builds: map[string]Build{
-				"firstoutthetrenches": {enqueued: false, Number: 10},
+				"firstoutthetrenches": {enqueued: false, Number: 10, Building: true},
 			},
 			expectedURL:    "firstoutthetrenches/pending",
 			expectedState:  prowapi.PendingState,
@@ -563,7 +563,7 @@ func TestSyncPendingJobs(t *testing.T) {
 				},
 			},
 			builds: map[string]Build{
-				"zerobuild": {enqueued: false, Number: 0},
+				"zerobuild": {enqueued: false, Number: 0, Building: true},
 			},
 			expectedState:  prowapi.PendingState,
 			expectedReport: false,

--- a/pkg/jenkins/controller_test.go
+++ b/pkg/jenkins/controller_test.go
@@ -313,7 +313,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 				"zerobuild": {enqueued: false, Number: 0, Building: true},
 			},
 			expectedBuild:       false,
-			expectedReport:      false,
+			expectedReport:      true, // report description
 			expectedState:       prowapi.TriggeredState,
 			expectedPendingTime: nil,
 		},
@@ -708,7 +708,7 @@ func TestBatch(t *testing.T) {
 	if afterFirstSync.Status.Description != "Jenkins job enqueued." {
 		t.Fatalf("Expected description %q, got %q.", "Jenkins job enqueued.", afterFirstSync.Status.Description)
 	}
-	jc.builds["known_name"] = Build{Number: 42}
+	jc.builds["known_name"] = Build{Number: 42, Building: true}
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on second sync: %v", err)
 	}
@@ -722,7 +722,7 @@ func TestBatch(t *testing.T) {
 	if afterSecondSync.Status.PodName != "known_name" {
 		t.Fatalf("Wrong PodName: %s", afterSecondSync.Status.PodName)
 	}
-	jc.builds["known_name"] = Build{Result: pState(success)}
+	jc.builds["known_name"] = Build{Result: pState(success), Number: 42}
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on third sync: %v", err)
 	}

--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	stdio "io"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -96,6 +97,7 @@ type Build struct {
 	} `json:"task"`
 	Number   int     `json:"number"`
 	Result   *string `json:"result"`
+	Building bool    `json:"building"`
 	enqueued bool
 }
 
@@ -123,22 +125,26 @@ type JobInfo struct {
 
 // IsRunning means the job started but has not finished.
 func (jb *Build) IsRunning() bool {
-	return jb.Result == nil && !jb.enqueued
+	// Consider builds running when Jenkins reports building=true.
+	// For backward-compatibility (older data/tests or Jenkins instances not populating `building`),
+	// also treat a build as running if it has been assigned a build number (>0),
+	// has not been enqueued anymore and has no terminal result yet.
+	return jb.Result == nil && !jb.enqueued && (jb.Building || jb.Number > 0)
 }
 
 // IsSuccess means the job passed
 func (jb *Build) IsSuccess() bool {
-	return jb.Result != nil && *jb.Result == success
+	return jb.Result != nil && *jb.Result == success && !jb.Building
 }
 
 // IsFailure means the job completed with problems.
 func (jb *Build) IsFailure() bool {
-	return jb.Result != nil && (*jb.Result == failure || *jb.Result == unstable)
+	return jb.Result != nil && (*jb.Result == failure || *jb.Result == unstable) && !jb.Building
 }
 
 // IsAborted means something stopped the job before it could finish.
 func (jb *Build) IsAborted() bool {
-	return jb.Result != nil && *jb.Result == aborted
+	return jb.Result != nil && *jb.Result == aborted && !jb.Building
 }
 
 // IsEnqueued means the job has created but has not started.
@@ -670,9 +676,7 @@ func (c *Client) ListBuilds(jobs []BuildQueryParams) (map[string]Build, error) {
 	}
 
 	for builds := range buildChan {
-		for id, build := range builds {
-			jenkinsBuilds[id] = build
-		}
+		maps.Copy(jenkinsBuilds, builds)
 	}
 
 	return jenkinsBuilds, nil
@@ -722,7 +726,7 @@ func (c *Client) GetEnqueuedBuilds(jobs []BuildQueryParams) (map[string]Build, e
 func (c *Client) GetBuilds(job string) (map[string]Build, error) {
 	c.logger.Debugf("GetBuilds(%v)", job)
 
-	data, err := c.Get(fmt.Sprintf("/job/%s/api/json?tree=builds[number,result,actions[parameters[name,value]]]", job))
+	data, err := c.Get(fmt.Sprintf("/job/%s/api/json?tree=builds[number,building,result,actions[parameters[name,value]]]", job))
 	if err != nil {
 		// Ignore 404s so we will not block processing the rest of the jobs.
 		if _, isNotFound := err.(NotFoundError); isNotFound {

--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -129,7 +129,7 @@ func (jb *Build) IsRunning() bool {
 	// For backward-compatibility (older data/tests or Jenkins instances not populating `building`),
 	// also treat a build as running if it has been assigned a build number (>0),
 	// has not been enqueued anymore and has no terminal result yet.
-	return jb.Result == nil && !jb.enqueued && (jb.Building || jb.Number > 0)
+	return jb.Result == nil && !jb.enqueued && jb.Building && jb.Number > 0
 }
 
 // IsSuccess means the job passed
@@ -149,7 +149,7 @@ func (jb *Build) IsAborted() bool {
 
 // IsEnqueued means the job has created but has not started.
 func (jb *Build) IsEnqueued() bool {
-	return jb.enqueued
+	return jb.enqueued || (!jb.Building && jb.Result == nil) || (jb.Building && jb.Number <= 0)
 }
 
 // ProwJobID extracts the ProwJob identifier for the


### PR DESCRIPTION
- Add Building bool to Build and update IsRunning, IsSuccess, IsFailure, and IsAborted to consider building state (with a fallback to Number>0 for backward compatibility). 
- Use `maps.Copy` to merge build maps and request the 'building' field from the Jenkins API.
- Update tests to include Building values.