### PR TITLE
fix(pkg/jenkins): fix handling for fast-failing Jenkins jobs

### DIFF
--- a/pkg/jenkins/controller.go
+++ b/pkg/jenkins/controller.go
@@ -471,6 +471,39 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 		} else {
 			pj.Status.URL = b.String()
 		}
+	} else {
+		// Build has already completed (fast-failing case). Handle the result immediately.
+		pj.SetComplete()
+		if pj.Status.PendingTime == nil {
+			now := metav1.NewTime(c.clock.Now())
+			pj.Status.PendingTime = &now
+		}
+
+		switch {
+		case jb.IsSuccess():
+			pj.Status.State = prowapi.SuccessState
+			pj.Status.Description = "Jenkins job succeeded."
+		case jb.IsFailure():
+			pj.Status.State = prowapi.FailureState
+			pj.Status.Description = "Jenkins job failed."
+		case jb.IsAborted():
+			pj.Status.State = prowapi.AbortedState
+			pj.Status.Description = "Jenkins job aborted."
+		default:
+			pj.Status.State = prowapi.ErrorState
+			pj.Status.Description = "Jenkins job completed with unknown result."
+		}
+
+		// Construct the status URL that will be used in reports.
+		pj.Status.PodName = pj.ObjectMeta.Name
+		pj.Status.BuildID = jb.BuildID()
+		pj.Status.JenkinsBuildID = strconv.Itoa(jb.Number)
+		var b bytes.Buffer
+		if err := c.config().JobURLTemplate.Execute(&b, &pj); err != nil {
+			c.log.WithFields(pjutil.ProwJobFields(&pj)).Errorf("error executing URL template: %v", err)
+		} else {
+			pj.Status.URL = b.String()
+		}
 	}
 	// Report to GitHub.
 	reports <- pj

--- a/pkg/jenkins/controller_test.go
+++ b/pkg/jenkins/controller_test.go
@@ -189,6 +189,7 @@ func (f *fghc) EditCommentWithContext(_ context.Context, org, repo string, ID in
 
 func TestSyncTriggeredJobs(t *testing.T) {
 	fakeClock := clocktesting.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	referenceTime := fakeClock.Now()
 
 	var testcases = []struct {
 		name           string
@@ -294,6 +295,75 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			expectedState:       prowapi.TriggeredState,
 			expectedEnqueued:    true,
 			expectedPendingTime: nil,
+		},
+		{
+			name: "fast-failing job - failure state",
+			pj: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fast-fail",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Type: prowapi.PostsubmitJob,
+					Job:  "test-job",
+				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.TriggeredState,
+				},
+			},
+			builds: map[string]Build{
+				"fast-fail": {Result: pState(failure), Number: 42},
+			},
+			expectedState:       prowapi.FailureState,
+			expectedComplete:    true,
+			expectedReport:      true,
+			expectedPendingTime: &metav1.Time{Time: referenceTime},
+		},
+		{
+			name: "fast-failing job - success state",
+			pj: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fast-success",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Type: prowapi.PostsubmitJob,
+					Job:  "test-job",
+				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.TriggeredState,
+				},
+			},
+			builds: map[string]Build{
+				"fast-success": {Result: pState(success), Number: 43},
+			},
+			expectedState:       prowapi.SuccessState,
+			expectedComplete:    true,
+			expectedReport:      true,
+			expectedPendingTime: &metav1.Time{Time: referenceTime},
+		},
+		{
+			name: "fast-failing job - aborted state",
+			pj: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fast-abort",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Type: prowapi.PostsubmitJob,
+					Job:  "test-job",
+				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.TriggeredState,
+				},
+			},
+			builds: map[string]Build{
+				"fast-abort": {Result: pState(aborted), Number: 44},
+			},
+			expectedState:       prowapi.AbortedState,
+			expectedComplete:    true,
+			expectedReport:      true,
+			expectedPendingTime: &metav1.Time{Time: referenceTime},
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
Handle fast-failing Jenkins jobs by setting appropriate state and
description
based on build result (success, failure, aborted, or unknown). Set
pending time
and mark job as complete. Added corresponding test cases for each state.

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
