### PR TITLE
feat(pod-utils): add pull author prow label

### DIFF
--- a/cmd/deck/rerun_test.go
+++ b/cmd/deck/rerun_test.go
@@ -596,6 +596,7 @@ func TestLatestRerun(t *testing.T) {
 							"prow.k8s.io/context":             "",
 							"prow.k8s.io/gerrit-report-label": "foo",
 							"prow.k8s.io/job":                 "whoa",
+							"prow.k8s.io/refs.author":         tc.login,
 							"prow.k8s.io/refs.base_ref":       "master",
 							"prow.k8s.io/refs.org":            "org",
 							"prow.k8s.io/refs.pull":           "1",

--- a/pkg/kube/prowjob.go
+++ b/pkg/kube/prowjob.go
@@ -64,6 +64,9 @@ const (
 	// PullLabel is added in resources created by prow and
 	// carries the PR number associated with the job, eg 321.
 	PullLabel = "prow.k8s.io/refs.pull"
+	// AuthorLabel is added in resources created by prow and
+	// carries the PR author associated with the job, eg octocat.
+	AuthorLabel = "prow.k8s.io/refs.author"
 	// RetestLabel exposes if the job was created by a re-test request.
 	RetestLabel = "prow.k8s.io/retest"
 	// IsOptionalLabel is added in resources created by prow and

--- a/pkg/pjutil/pjutil_test.go
+++ b/pkg/pjutil/pjutil_test.go
@@ -1064,6 +1064,7 @@ func TestNewPresubmitWithModifiers(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.BaseRefLabel:      "base-ref",
 						kube.PullLabel:         "42",
+						kube.AuthorLabel:       "user-login",
 						"extra-label":          "foo",
 					},
 					Annotations: map[string]string{
@@ -1130,6 +1131,7 @@ func TestNewPresubmitWithModifiers(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.BaseRefLabel:      "base-ref",
 						kube.PullLabel:         "42",
+						kube.AuthorLabel:       "user-login",
 						"extra-label":          "foo",
 					},
 					Annotations: map[string]string{

--- a/pkg/pod-utils/decorate/podspec.go
+++ b/pkg/pod-utils/decorate/podspec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package decorate
 
 import (
+	"encoding/json"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -185,7 +186,33 @@ func LabelsAndAnnotationsForJob(pj prowapi.ProwJob) (map[string]string, map[stri
 	}
 	extraLabels[kube.ProwJobIDLabel] = pj.ObjectMeta.Name
 	extraLabels[kube.ProwBuildIDLabel] = pj.Status.BuildID
-	return LabelsAndAnnotationsForSpec(pj.Spec, extraLabels, extraAnnotations)
+	labels, annotations := LabelsAndAnnotationsForSpec(pj.Spec, extraLabels, extraAnnotations)
+	for k, v := range ciAnnotationsForJob(pj) {
+		if _, exists := annotations[k]; !exists {
+			annotations[k] = v
+		}
+	}
+	return labels, annotations
+}
+
+func ciAnnotationsForJob(pj prowapi.ProwJob) map[string]string {
+	annotations := map[string]string{}
+	if pj.Spec.Job != "" {
+		annotations["ci_job"] = pj.Spec.Job
+	}
+	if pj.Spec.Refs == nil {
+		return annotations
+	}
+	refs, err := json.Marshal(pj.Spec.Refs)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to marshal ci_refs annotation.")
+	} else {
+		annotations["ci_refs"] = string(refs)
+	}
+	if len(pj.Spec.Refs.Pulls) > 0 && pj.Spec.Refs.Pulls[0].Author != "" {
+		annotations["ci_trigger_user"] = pj.Spec.Refs.Pulls[0].Author
+	}
+	return annotations
 }
 
 // ProwJobToPod converts a ProwJob to a Pod that will run the tests.

--- a/pkg/pod-utils/decorate/podspec.go
+++ b/pkg/pod-utils/decorate/podspec.go
@@ -17,7 +17,6 @@ limitations under the License.
 package decorate
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -142,6 +141,7 @@ func LabelsAndAnnotationsForSpec(spec prowapi.ProwJobSpec, extraLabels, extraAnn
 		labels[kube.BaseRefLabel] = refs.BaseRef
 		if len(refs.Pulls) > 0 {
 			labels[kube.PullLabel] = strconv.Itoa(refs.Pulls[0].Number)
+			labels[kube.AuthorLabel] = refs.Pulls[0].Author
 		}
 	}
 
@@ -186,33 +186,7 @@ func LabelsAndAnnotationsForJob(pj prowapi.ProwJob) (map[string]string, map[stri
 	}
 	extraLabels[kube.ProwJobIDLabel] = pj.ObjectMeta.Name
 	extraLabels[kube.ProwBuildIDLabel] = pj.Status.BuildID
-	labels, annotations := LabelsAndAnnotationsForSpec(pj.Spec, extraLabels, extraAnnotations)
-	for k, v := range ciAnnotationsForJob(pj) {
-		if _, exists := annotations[k]; !exists {
-			annotations[k] = v
-		}
-	}
-	return labels, annotations
-}
-
-func ciAnnotationsForJob(pj prowapi.ProwJob) map[string]string {
-	annotations := map[string]string{}
-	if pj.Spec.Job != "" {
-		annotations["ci_job"] = pj.Spec.Job
-	}
-	if pj.Spec.Refs == nil {
-		return annotations
-	}
-	refs, err := json.Marshal(pj.Spec.Refs)
-	if err != nil {
-		logrus.WithError(err).Warn("Failed to marshal ci_refs annotation.")
-	} else {
-		annotations["ci_refs"] = string(refs)
-	}
-	if len(pj.Spec.Refs.Pulls) > 0 && pj.Spec.Refs.Pulls[0].Author != "" {
-		annotations["ci_trigger_user"] = pj.Spec.Refs.Pulls[0].Author
-	}
-	return annotations
+	return LabelsAndAnnotationsForSpec(pj.Spec, extraLabels, extraAnnotations)
 }
 
 // ProwJobToPod converts a ProwJob to a Pod that will run the tests.

--- a/pkg/pod-utils/decorate/podspec.go
+++ b/pkg/pod-utils/decorate/podspec.go
@@ -141,7 +141,9 @@ func LabelsAndAnnotationsForSpec(spec prowapi.ProwJobSpec, extraLabels, extraAnn
 		labels[kube.BaseRefLabel] = refs.BaseRef
 		if len(refs.Pulls) > 0 {
 			labels[kube.PullLabel] = strconv.Itoa(refs.Pulls[0].Number)
-			labels[kube.AuthorLabel] = refs.Pulls[0].Author
+			if refs.Pulls[0].Author != "" {
+				labels[kube.AuthorLabel] = refs.Pulls[0].Author
+			}
 		}
 	}
 

--- a/pkg/pod-utils/decorate/podspec_test.go
+++ b/pkg/pod-utils/decorate/podspec_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/prow/pkg/gcsupload"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/initupload"
+	"sigs.k8s.io/prow/pkg/kube"
 	"sigs.k8s.io/prow/pkg/pod-utils/wrapper"
 	"sigs.k8s.io/prow/pkg/sidecar"
 	"sigs.k8s.io/prow/pkg/testutil"
@@ -65,101 +66,98 @@ func cookiePathOnly(secret string) string {
 	return vp
 }
 
-func TestCIAnnotationsForJob(t *testing.T) {
+func TestLabelsAndAnnotationsForSpecAddsPullAuthorLabel(t *testing.T) {
 	tests := []struct {
-		name string
-		pj   prowapi.ProwJob
-		want map[string]string
+		name       string
+		spec       prowapi.ProwJobSpec
+		extraLabel map[string]string
+		want       string
+		wantExists bool
 	}{
 		{
 			name: "presubmit with pull author",
-			pj: prowapi.ProwJob{
-				Spec: prowapi.ProwJobSpec{
-					Job: "pull-test",
-					Refs: &prowapi.Refs{
-						Org:     "pingcap",
-						Repo:    "tidb",
-						BaseRef: "master",
-						BaseSHA: "base-sha",
-						Pulls: []prowapi.Pull{{
-							Number:  123,
-							Author:  "pr-author",
-							SHA:     "pull-sha",
-							Title:   "pull title",
-							HeadRef: "feature-branch",
-						}},
-					},
-				},
-			},
-			want: map[string]string{
-				"ci_job":          "pull-test",
-				"ci_refs":         `{"org":"pingcap","repo":"tidb","base_ref":"master","base_sha":"base-sha","pulls":[{"number":123,"author":"pr-author","sha":"pull-sha","title":"pull title","head_ref":"feature-branch"}]}`,
-				"ci_trigger_user": "pr-author",
-			},
-		},
-		{
-			name: "periodic without refs",
-			pj: prowapi.ProwJob{
-				Spec: prowapi.ProwJobSpec{Job: "periodic-test"},
-			},
-			want: map[string]string{
-				"ci_job": "periodic-test",
-			},
-		},
-		{
-			name: "postsubmit with refs but no pulls",
-			pj: prowapi.ProwJob{
-				Spec: prowapi.ProwJobSpec{
-					Job: "postsubmit-test",
-					Refs: &prowapi.Refs{
-						Org:     "pingcap",
-						Repo:    "tidb",
-						BaseRef: "master",
-						BaseSHA: "base-sha",
-					},
-				},
-			},
-			want: map[string]string{
-				"ci_job":  "postsubmit-test",
-				"ci_refs": `{"org":"pingcap","repo":"tidb","base_ref":"master","base_sha":"base-sha"}`,
-			},
-		},
-		{
-			name: "extra refs do not become ci_refs",
-			pj: prowapi.ProwJob{
-				Spec: prowapi.ProwJobSpec{
-					Job: "extra-ref-test",
-					ExtraRefs: []prowapi.Refs{{
-						Org:  "pingcap",
-						Repo: "tidb",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:     "pingcap",
+					Repo:    "tidb",
+					BaseRef: "master",
+					BaseSHA: "base-sha",
+					Pulls: []prowapi.Pull{{
+						Number: 123,
+						Author: "pr-author",
+						SHA:    "pull-sha",
 					}},
 				},
 			},
-			want: map[string]string{
-				"ci_job": "extra-ref-test",
+			want:       "pr-author",
+			wantExists: true,
+		},
+		{
+			name: "postsubmit with refs but no pulls",
+			spec: prowapi.ProwJobSpec{
+				Job: "postsubmit-test",
+				Refs: &prowapi.Refs{
+					Org:     "pingcap",
+					Repo:    "tidb",
+					BaseRef: "master",
+					BaseSHA: "base-sha",
+				},
 			},
+		},
+		{
+			name: "invalid author is removed by label validation",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:  "pingcap",
+					Repo: "tidb",
+					Pulls: []prowapi.Pull{{
+						Number: 123,
+						Author: "bad author",
+					}},
+				},
+			},
+		},
+		{
+			name: "extra labels can override author",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:  "pingcap",
+					Repo: "tidb",
+					Pulls: []prowapi.Pull{{
+						Number: 123,
+						Author: "pr-author",
+					}},
+				},
+			},
+			extraLabel: map[string]string{
+				kube.AuthorLabel: "custom-author",
+			},
+			want:       "custom-author",
+			wantExists: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ciAnnotationsForJob(tc.pj)
-			if !equality.Semantic.DeepEqual(got, tc.want) {
-				t.Fatalf("unexpected ci annotations:\n%s", diff.ObjectReflectDiff(tc.want, got))
+			got, _ := LabelsAndAnnotationsForSpec(tc.spec, tc.extraLabel, nil)
+			value, exists := got[kube.AuthorLabel]
+			if exists != tc.wantExists {
+				t.Fatalf("expected author label existence %t, got %t", tc.wantExists, exists)
+			}
+			if value != tc.want {
+				t.Fatalf("expected author label %q, got %q", tc.want, value)
 			}
 		})
 	}
 }
 
-func TestLabelsAndAnnotationsForJobPreservesExistingCIAnnotations(t *testing.T) {
-	_, got := LabelsAndAnnotationsForJob(prowapi.ProwJob{
+func TestLabelsAndAnnotationsForJobAddsPullAuthorLabel(t *testing.T) {
+	got, _ := LabelsAndAnnotationsForJob(prowapi.ProwJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pj",
-			Annotations: map[string]string{
-				"ci_job":          "custom-job",
-				"ci_refs":         "custom-refs",
-				"ci_trigger_user": "custom-user",
-			},
 		},
 		Spec: prowapi.ProwJobSpec{
 			Job:     "pull-test",
@@ -176,15 +174,8 @@ func TestLabelsAndAnnotationsForJobPreservesExistingCIAnnotations(t *testing.T) 
 		},
 	})
 
-	want := map[string]string{
-		"ci_job":          "custom-job",
-		"ci_refs":         "custom-refs",
-		"ci_trigger_user": "custom-user",
-	}
-	for key, value := range want {
-		if got[key] != value {
-			t.Fatalf("expected %s=%q, got %q", key, value, got[key])
-		}
+	if got[kube.AuthorLabel] != "pr-author" {
+		t.Fatalf("expected author label %q, got %q", "pr-author", got[kube.AuthorLabel])
 	}
 }
 

--- a/pkg/pod-utils/decorate/podspec_test.go
+++ b/pkg/pod-utils/decorate/podspec_test.go
@@ -65,6 +65,129 @@ func cookiePathOnly(secret string) string {
 	return vp
 }
 
+func TestCIAnnotationsForJob(t *testing.T) {
+	tests := []struct {
+		name string
+		pj   prowapi.ProwJob
+		want map[string]string
+	}{
+		{
+			name: "presubmit with pull author",
+			pj: prowapi.ProwJob{
+				Spec: prowapi.ProwJobSpec{
+					Job: "pull-test",
+					Refs: &prowapi.Refs{
+						Org:     "pingcap",
+						Repo:    "tidb",
+						BaseRef: "master",
+						BaseSHA: "base-sha",
+						Pulls: []prowapi.Pull{{
+							Number:  123,
+							Author:  "pr-author",
+							SHA:     "pull-sha",
+							Title:   "pull title",
+							HeadRef: "feature-branch",
+						}},
+					},
+				},
+			},
+			want: map[string]string{
+				"ci_job":          "pull-test",
+				"ci_refs":         `{"org":"pingcap","repo":"tidb","base_ref":"master","base_sha":"base-sha","pulls":[{"number":123,"author":"pr-author","sha":"pull-sha","title":"pull title","head_ref":"feature-branch"}]}`,
+				"ci_trigger_user": "pr-author",
+			},
+		},
+		{
+			name: "periodic without refs",
+			pj: prowapi.ProwJob{
+				Spec: prowapi.ProwJobSpec{Job: "periodic-test"},
+			},
+			want: map[string]string{
+				"ci_job": "periodic-test",
+			},
+		},
+		{
+			name: "postsubmit with refs but no pulls",
+			pj: prowapi.ProwJob{
+				Spec: prowapi.ProwJobSpec{
+					Job: "postsubmit-test",
+					Refs: &prowapi.Refs{
+						Org:     "pingcap",
+						Repo:    "tidb",
+						BaseRef: "master",
+						BaseSHA: "base-sha",
+					},
+				},
+			},
+			want: map[string]string{
+				"ci_job":  "postsubmit-test",
+				"ci_refs": `{"org":"pingcap","repo":"tidb","base_ref":"master","base_sha":"base-sha"}`,
+			},
+		},
+		{
+			name: "extra refs do not become ci_refs",
+			pj: prowapi.ProwJob{
+				Spec: prowapi.ProwJobSpec{
+					Job: "extra-ref-test",
+					ExtraRefs: []prowapi.Refs{{
+						Org:  "pingcap",
+						Repo: "tidb",
+					}},
+				},
+			},
+			want: map[string]string{
+				"ci_job": "extra-ref-test",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ciAnnotationsForJob(tc.pj)
+			if !equality.Semantic.DeepEqual(got, tc.want) {
+				t.Fatalf("unexpected ci annotations:\n%s", diff.ObjectReflectDiff(tc.want, got))
+			}
+		})
+	}
+}
+
+func TestLabelsAndAnnotationsForJobPreservesExistingCIAnnotations(t *testing.T) {
+	_, got := LabelsAndAnnotationsForJob(prowapi.ProwJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pj",
+			Annotations: map[string]string{
+				"ci_job":          "custom-job",
+				"ci_refs":         "custom-refs",
+				"ci_trigger_user": "custom-user",
+			},
+		},
+		Spec: prowapi.ProwJobSpec{
+			Job:     "pull-test",
+			Type:    prowapi.PresubmitJob,
+			Context: "pull-test",
+			Refs: &prowapi.Refs{
+				Org:  "pingcap",
+				Repo: "tidb",
+				Pulls: []prowapi.Pull{{
+					Number: 1,
+					Author: "pr-author",
+				}},
+			},
+		},
+	})
+
+	want := map[string]string{
+		"ci_job":          "custom-job",
+		"ci_refs":         "custom-refs",
+		"ci_trigger_user": "custom-user",
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("expected %s=%q, got %q", key, value, got[key])
+		}
+	}
+}
+
 func TestCloneRefs(t *testing.T) {
 	truth := true
 	logMount := coreapi.VolumeMount{

--- a/pkg/pod-utils/decorate/podspec_test.go
+++ b/pkg/pod-utils/decorate/podspec_test.go
@@ -106,6 +106,19 @@ func TestLabelsAndAnnotationsForSpecAddsPullAuthorLabel(t *testing.T) {
 			},
 		},
 		{
+			name: "presubmit with empty pull author",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:  "pingcap",
+					Repo: "tidb",
+					Pulls: []prowapi.Pull{{
+						Number: 123,
+					}},
+				},
+			},
+		},
+		{
 			name: "invalid author is removed by label validation",
 			spec: prowapi.ProwJobSpec{
 				Job: "pull-test",

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_0.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_0.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"pull-branch-name"}]}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_0.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_0.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"pull-branch-name"}]}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"my-big-change"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"my-big-change"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_10.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_10.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_10.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_10.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"fix-typos-99"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"fix-typos-99"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"fixes-fixes-fixes"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"fixes-fixes-fixes"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"fixes-9"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"fixes-9"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -1,5 +1,6 @@
 metadata:
   annotations:
+    ci_job: job-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -1,6 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"best-branch-name"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"best-branch-name"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"pr-head-ref-11"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"pr-head-ref-11"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
@@ -1,5 +1,8 @@
 metadata:
   annotations:
+    ci_job: job-name
+    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"}'
+    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
@@ -1,8 +1,5 @@
 metadata:
   annotations:
-    ci_job: job-name
-    ci_refs: '{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","title":"pull-title","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"}'
-    ci_trigger_user: author-name
     prow.k8s.io/context: job-context
     prow.k8s.io/job: job-name
   creationTimestamp: null
@@ -13,6 +10,7 @@ metadata:
     prow.k8s.io/context: job-context
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
+    prow.k8s.io/refs.author: author-name
     prow.k8s.io/refs.base_ref: base-ref
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"


### PR DESCRIPTION
## What

Add a native Prow metadata label to Pods created from ProwJobs:

- `prow.k8s.io/refs.author`: PR author from `ProwJob.Spec.Refs.Pulls[0].Author`

Prow already labels direct job Pods with job/repo/ref metadata such as `prow.k8s.io/job`, `prow.k8s.io/refs.org`, `prow.k8s.io/refs.repo`, and `prow.k8s.io/refs.pull`. This change only fills the missing PR author dimension and keeps the same `prow.k8s.io/refs.*` style.

The label is added through the existing Prow label path, so it reuses the existing Kubernetes label validation. If the author value is invalid as a label value, Prow removes that label instead of failing Pod creation.

## What Changed From The Previous Approach

This PR no longer adds Jenkins-style `ci_*` annotations. Direct Prow Pods can set labels before Pod creation, so they do not need the Jenkins annotation-to-Kyverno-label indirection.

Removed from the earlier version:

- `ci_job`
- `ci_refs`
- `ci_trigger_user`

## Tests

- `go test ./pkg/pod-utils/decorate -run TestProwJobToPod -count=1`
- `go test ./pkg/pod-utils/decorate -count=1`

## Follow-up

After the new `prow-controller-manager` image is published, update ee-ops to bump the PCM image tag. No Kyverno change is needed for direct Prow Pods to get the author label, because Prow now writes `prow.k8s.io/refs.author` directly.
