### PR TITLE
feat(pod-utils): add target branch prow label

### DIFF
--- a/cmd/deck/rerun_test.go
+++ b/cmd/deck/rerun_test.go
@@ -601,6 +601,7 @@ func TestLatestRerun(t *testing.T) {
 							"prow.k8s.io/refs.org":            "org",
 							"prow.k8s.io/refs.pull":           "1",
 							"prow.k8s.io/refs.repo":           "repo",
+							kube.TargetBranchLabel:            "master",
 							"prow.k8s.io/type":                string(tc.pjType),
 						},
 						Annotations: map[string]string{

--- a/pkg/gerrit/adapter/adapter_test.go
+++ b/pkg/gerrit/adapter/adapter_test.go
@@ -622,6 +622,20 @@ func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCache, erro
 	return cache, nil
 }
 
+func addExpectedTargetBranchLabels(prowjobs []*prowapi.ProwJob) {
+	for _, prowjob := range prowjobs {
+		if prowjob == nil || prowjob.Spec.Refs == nil || prowjob.Spec.Refs.BaseRef == "" {
+			continue
+		}
+		if prowjob.Labels == nil {
+			prowjob.Labels = map[string]string{}
+		}
+		if targetBranch := kube.SanitizeCIRefLabelValue(prowjob.Spec.Refs.BaseRef); targetBranch != "" {
+			prowjob.Labels[kube.TargetBranchLabel] = targetBranch
+		}
+	}
+}
+
 func TestTriggerJobs(t *testing.T) {
 	testInstance := "https://gerrit"
 	var testcases = []struct {
@@ -3262,6 +3276,8 @@ func TestTriggerJobs(t *testing.T) {
 					}
 				}
 			}
+
+			addExpectedTargetBranchLabels(tc.wantPjs)
 
 			// It seems that the PJs are very deterministic, consider sorting
 			// them if this test becomes flaky.

--- a/pkg/kube/prowjob.go
+++ b/pkg/kube/prowjob.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package kube
 
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
 const (
 	// CreatedByProw is added on resources created by prow.
 	// Since resources often live in another cluster/namespace,
@@ -59,8 +65,12 @@ const (
 	// carries the repo associated with the job, eg test-infra
 	RepoLabel = "prow.k8s.io/refs.repo"
 	// BaseRefLabel is added in resources created by prow and
-	// carries the base ref associated with the job, eg main
+	// carries the raw base ref associated with the job, eg main.
 	BaseRefLabel = "prow.k8s.io/refs.base_ref"
+	// TargetBranchLabel is added in resources created by prow and
+	// carries the sanitized target branch associated with the job as a
+	// Kubernetes label value, eg release-8_5 for release-8.5.
+	TargetBranchLabel = "prow.k8s.io/refs.target_branch"
 	// PullLabel is added in resources created by prow and
 	// carries the PR number associated with the job, eg 321.
 	PullLabel = "prow.k8s.io/refs.pull"
@@ -89,3 +99,23 @@ const (
 	// GerritReportLabel is the gerrit label prow will cast vote on, fallback to CodeReview label if unset
 	GerritReportLabel = "prow.k8s.io/gerrit-report-label"
 )
+
+// SanitizeCIRefLabelValue sanitizes a CI ref into a Kubernetes label value.
+// It returns an empty string when the ref has no usable label value.
+func SanitizeCIRefLabelValue(value string) string {
+	value = strings.ToLower(value)
+	var b strings.Builder
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+
+	sanitized := strings.Trim(b.String(), "_-")
+	if len(sanitized) > validation.LabelValueMaxLength {
+		sanitized = strings.TrimRight(sanitized[:validation.LabelValueMaxLength], "_-")
+	}
+	return sanitized
+}

--- a/pkg/kube/prowjob_test.go
+++ b/pkg/kube/prowjob_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package kube
 
 import (
+	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 )
@@ -89,5 +92,57 @@ func TestRefs(t *testing.T) {
 		if actual != tc.expected {
 			t.Errorf("Ref %+v, got %s, expected, %s", tc.ref, actual, tc.expected)
 		}
+	}
+}
+
+func TestSanitizeCIRefLabelValue(t *testing.T) {
+	longRef := strings.Repeat("a", validation.LabelValueMaxLength) + ".suffix"
+	testcases := []struct {
+		name     string
+		ref      string
+		expected string
+	}{
+		{
+			name:     "simple branch",
+			ref:      "master",
+			expected: "master",
+		},
+		{
+			name:     "dot and slash become underscores",
+			ref:      "release-8.5/hotfix",
+			expected: "release-8_5_hotfix",
+		},
+		{
+			name:     "uppercase is lowercased",
+			ref:      "InRepoConfig",
+			expected: "inrepoconfig",
+		},
+		{
+			name:     "leading and trailing separators are trimmed",
+			ref:      "_-release-8.5-_",
+			expected: "release-8_5",
+		},
+		{
+			name:     "all invalid characters becomes empty",
+			ref:      "!!!",
+			expected: "",
+		},
+		{
+			name:     "long branch is truncated",
+			ref:      longRef,
+			expected: strings.Repeat("a", validation.LabelValueMaxLength),
+		},
+		{
+			name:     "truncated branch trims trailing separator",
+			ref:      strings.Repeat("a", validation.LabelValueMaxLength-1) + "-suffix",
+			expected: strings.Repeat("a", validation.LabelValueMaxLength-1),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := SanitizeCIRefLabelValue(tc.ref); actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
 	}
 }

--- a/pkg/pjutil/pjutil_test.go
+++ b/pkg/pjutil/pjutil_test.go
@@ -628,6 +628,7 @@ func TestNewProwJob(t *testing.T) {
 				kube.OrgLabel:          "org",
 				kube.RepoLabel:         "repo",
 				kube.BaseRefLabel:      "main",
+				kube.TargetBranchLabel: "main",
 			},
 			expectedAnnotations: map[string]string{
 				kube.ProwJobAnnotation: "job",
@@ -658,6 +659,7 @@ func TestNewProwJob(t *testing.T) {
 				kube.OrgLabel:          "org",
 				kube.RepoLabel:         "repo",
 				kube.BaseRefLabel:      "main",
+				kube.TargetBranchLabel: "main",
 				kube.PullLabel:         "1",
 			},
 			expectedAnnotations: map[string]string{
@@ -689,6 +691,7 @@ func TestNewProwJob(t *testing.T) {
 				kube.OrgLabel:          "some-gerrit-instance.foo.com",
 				kube.RepoLabel:         "repo",
 				kube.BaseRefLabel:      "main",
+				kube.TargetBranchLabel: "main",
 				kube.PullLabel:         "1",
 			},
 			expectedAnnotations: map[string]string{
@@ -719,6 +722,7 @@ func TestNewProwJob(t *testing.T) {
 				kube.OrgLabel:          "org",
 				kube.RepoLabel:         "repo",
 				kube.BaseRefLabel:      "main",
+				kube.TargetBranchLabel: "main",
 				kube.PullLabel:         "1",
 			},
 			expectedAnnotations: map[string]string{
@@ -750,6 +754,7 @@ func TestNewProwJob(t *testing.T) {
 				kube.OrgLabel:          "org",
 				kube.RepoLabel:         "repo",
 				kube.BaseRefLabel:      "main",
+				kube.TargetBranchLabel: "main",
 				kube.PullLabel:         "1",
 			},
 			expectedAnnotations: map[string]string{
@@ -1063,6 +1068,7 @@ func TestNewPresubmitWithModifiers(t *testing.T) {
 						kube.OrgLabel:          "kubernetes",
 						kube.RepoLabel:         "repo-name",
 						kube.BaseRefLabel:      "base-ref",
+						kube.TargetBranchLabel: "base-ref",
 						kube.PullLabel:         "42",
 						kube.AuthorLabel:       "user-login",
 						"extra-label":          "foo",
@@ -1130,6 +1136,7 @@ func TestNewPresubmitWithModifiers(t *testing.T) {
 						kube.OrgLabel:          "kubernetes",
 						kube.RepoLabel:         "repo-name",
 						kube.BaseRefLabel:      "base-ref",
+						kube.TargetBranchLabel: "base-ref",
 						kube.PullLabel:         "42",
 						kube.AuthorLabel:       "user-login",
 						"extra-label":          "foo",

--- a/pkg/pod-utils/decorate/podspec.go
+++ b/pkg/pod-utils/decorate/podspec.go
@@ -139,6 +139,9 @@ func LabelsAndAnnotationsForSpec(spec prowapi.ProwJobSpec, extraLabels, extraAnn
 		labels[kube.OrgLabel] = refs.Org
 		labels[kube.RepoLabel] = refs.Repo
 		labels[kube.BaseRefLabel] = refs.BaseRef
+		if targetBranch := kube.SanitizeCIRefLabelValue(refs.BaseRef); targetBranch != "" {
+			labels[kube.TargetBranchLabel] = targetBranch
+		}
 		if len(refs.Pulls) > 0 {
 			labels[kube.PullLabel] = strconv.Itoa(refs.Pulls[0].Number)
 			if refs.Pulls[0].Author != "" {

--- a/pkg/pod-utils/decorate/podspec_test.go
+++ b/pkg/pod-utils/decorate/podspec_test.go
@@ -192,6 +192,121 @@ func TestLabelsAndAnnotationsForJobAddsPullAuthorLabel(t *testing.T) {
 	}
 }
 
+func TestLabelsAndAnnotationsForSpecAddsTargetBranchLabel(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       prowapi.ProwJobSpec
+		extraLabel map[string]string
+		want       string
+		wantExists bool
+	}{
+		{
+			name: "master branch",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:     "pingcap",
+					Repo:    "tidb",
+					BaseRef: "master",
+				},
+			},
+			want:       "master",
+			wantExists: true,
+		},
+		{
+			name: "release branch with dot",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:     "pingcap",
+					Repo:    "tidb",
+					BaseRef: "release-8.5",
+				},
+			},
+			want:       "release-8_5",
+			wantExists: true,
+		},
+		{
+			name: "feature branch with slash and dot",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:     "pingcap",
+					Repo:    "tidb",
+					BaseRef: "Feature/foo.bar",
+				},
+			},
+			want:       "feature_foo_bar",
+			wantExists: true,
+		},
+		{
+			name: "empty base ref",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:  "pingcap",
+					Repo: "tidb",
+				},
+			},
+		},
+		{
+			name: "extra labels can override target branch",
+			spec: prowapi.ProwJobSpec{
+				Job: "pull-test",
+				Refs: &prowapi.Refs{
+					Org:     "pingcap",
+					Repo:    "tidb",
+					BaseRef: "master",
+				},
+			},
+			extraLabel: map[string]string{
+				kube.TargetBranchLabel: "custom-branch",
+			},
+			want:       "custom-branch",
+			wantExists: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := LabelsAndAnnotationsForSpec(tc.spec, tc.extraLabel, nil)
+			value, exists := got[kube.TargetBranchLabel]
+			if exists != tc.wantExists {
+				t.Fatalf("expected target branch label existence %t, got %t", tc.wantExists, exists)
+			}
+			if value != tc.want {
+				t.Fatalf("expected target branch label %q, got %q", tc.want, value)
+			}
+		})
+	}
+}
+
+func TestLabelsAndAnnotationsForJobAddsTargetBranchLabel(t *testing.T) {
+	got, _ := LabelsAndAnnotationsForJob(prowapi.ProwJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pj",
+		},
+		Spec: prowapi.ProwJobSpec{
+			Job:     "pull-test",
+			Type:    prowapi.PresubmitJob,
+			Context: "pull-test",
+			Refs: &prowapi.Refs{
+				Org:     "pingcap",
+				Repo:    "tidb",
+				BaseRef: "release-8.5",
+				Pulls: []prowapi.Pull{{
+					Number: 1,
+					Author: "pr-author",
+				}},
+			},
+		},
+	})
+
+	if got[kube.TargetBranchLabel] != "release-8_5" {
+		t.Fatalf("expected target branch label %q, got %q", "release-8_5", got[kube.TargetBranchLabel])
+	}
+}
+
 func TestCloneRefs(t *testing.T) {
 	truth := true
 	logMount := coreapi.VolumeMount{

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_0.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_0.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_10.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_10.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:

--- a/pkg/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
+++ b/pkg/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
@@ -15,6 +15,7 @@ metadata:
     prow.k8s.io/refs.org: org-name
     prow.k8s.io/refs.pull: "1"
     prow.k8s.io/refs.repo: repo-name
+    prow.k8s.io/refs.target_branch: base-ref
     prow.k8s.io/type: presubmit
   name: pod
 spec:


### PR DESCRIPTION
## Summary
- add `prow.k8s.io/refs.target_branch` for Prow-created resources
- derive the value from `refs.BaseRef` using best-effort Kubernetes label sanitization
- skip empty sanitized values so label generation never blocks ProwJob or pod creation
- update pod decoration tests and golden fixtures

## Verification
- `go test ./pkg/pod-utils/decorate`